### PR TITLE
Fixes interface_attrs method and updates gemspec

### DIFF
--- a/hammer_cli_foreman_azure_rm.gemspec
+++ b/hammer_cli_foreman_azure_rm.gemspec
@@ -4,7 +4,7 @@ require "hammer_cli_foreman_azure_rm/version"
 Gem::Specification.new do |s|
   s.name = "hammer_cli_foreman_azure_rm"
   s.authors = ["Aditi Puntambekar"]
-  s.homepage = 'https://github.com/apuntamb/hammer_cli_foreman_azure_rm'
+  s.homepage = 'https://github.com/theforeman/hammer_cli_foreman_azure_rm'
   s.version = HammerCLIForemanAzureRM.version.dup
   s.license = 'GPL-3.0'
   s.platform = Gem::Platform::RUBY

--- a/lib/hammer_cli_foreman_azure_rm/compute_resources/azure_rm.rb
+++ b/lib/hammer_cli_foreman_azure_rm/compute_resources/azure_rm.rb
@@ -10,13 +10,14 @@ module HammerCLIForemanAzureRM
       def compute_attributes
         [
           ['resource_group', _('Existing Azure Resource Group of user')],
-          ['vm_size', _('VM Size, eg. Standard A0 etc.')],
+          ['vm_size', _('VM Size, eg. Standard_A0 etc.')],
           ['username', _('The Admin username')],
           ['password', _('The Admin password')],
-          ['platform', _('OS type')],
+          ['platform', _('OS type eg. Linux')],
           ['ssh_key_data', _('SSH key for passwordless authentication')],
           ['os_disk_caching', _('OS disk caching')],
           ['premium_os_disk', _('Premium OS Disk, Boolean as 0 or 1')],
+          ['image_id', _('ID of image used')],
           ['script_command', _('Custom Script Command')],
           ['script_uris', _('Comma seperated file URIs')]
         ]
@@ -30,10 +31,11 @@ module HammerCLIForemanAzureRM
 
       def interface_attributes
         [
-          ['public_ip',  _('Public IP (None, Static, Dynamic)')],
-          ['network',    _('Select one of available Azure Subnets, must be an ID')],
-          ['private_ip', _('Static Private IP (expressed as 0 or 1)')]
+          ['compute_network',    _('Select one of available Azure Subnets, must be an ID')],
+          ['compute_public_ip',  _('Public IP (None, Static, Dynamic)')],
+          ['compute_private_ip', _('Static Private IP (expressed as true or false)')]
         ]
+      end
 
       def provider_specific_fields
         [


### PR DESCRIPTION
This PR handles a minor syntax error in the `interface_attributes` method i.e. the keys under interface section of a compute resource should be prefixed with the term `compute_`  and also updates the gemspec to the correct repo URL.