### PR TITLE
Fixes #28707 - Show version

### DIFF
--- a/hammer_cli_foreman_azure_rm.gemspec
+++ b/hammer_cli_foreman_azure_rm.gemspec
@@ -5,7 +5,7 @@ Gem::Specification.new do |s|
   s.name = "hammer_cli_foreman_azure_rm"
   s.authors = ["Aditi Puntambekar"]
   s.homepage = 'https://github.com/theforeman/hammer_cli_foreman_azure_rm'
-  s.version = HammerCLIForemanAzureRM.version.dup
+  s.version = HammerCLIForemanAzureRm.version.dup
   s.license = 'GPL-3.0'
   s.platform = Gem::Platform::RUBY
   s.summary = 'Foreman AzureRM commands for Hammer CLI'

--- a/lib/hammer_cli_foreman_azure_rm.rb
+++ b/lib/hammer_cli_foreman_azure_rm.rb
@@ -1,6 +1,7 @@
-module HammerCLIForemanAzureRM
+module HammerCLIForemanAzureRm
+  require 'hammer_cli_foreman_azure_rm/version'
   require 'hammer_cli_foreman_azure_rm/compute_resources/azure_rm'
   require 'hammer_cli_foreman/compute_resource/register_compute_resources'
 
-  HammerCLIForeman.register_compute_resource('azurerm', HammerCLIForemanAzureRM::ComputeResources::AzureRM.new)
+  HammerCLIForeman.register_compute_resource('azurerm', HammerCLIForemanAzureRm::ComputeResources::AzureRm.new)
 end

--- a/lib/hammer_cli_foreman_azure_rm/compute_resources/azure_rm.rb
+++ b/lib/hammer_cli_foreman_azure_rm/compute_resources/azure_rm.rb
@@ -1,8 +1,8 @@
 require 'hammer_cli_foreman/compute_resource/base'
 
-module HammerCLIForemanAzureRM
+module HammerCLIForemanAzureRm
   module ComputeResources
-    class AzureRM < HammerCLIForeman::ComputeResources::Base
+    class AzureRm < HammerCLIForeman::ComputeResources::Base
       def name
         _('AzureRM')
       end

--- a/lib/hammer_cli_foreman_azure_rm/version.rb
+++ b/lib/hammer_cli_foreman_azure_rm/version.rb
@@ -1,4 +1,4 @@
-module HammerCLIForemanAzureRM
+module HammerCLIForemanAzureRm
   def self.version
     @version ||= Gem::Version.new '0.1.2'
   end


### PR DESCRIPTION
Since the hammer core searches for constants created by capitalizing the name of a plugin, the constant should be different (`HammerCLIForemanAzureRm` or `HammerCliForemanAzureRm`).

I haven't changed the constant everywhere since for the purpose of showing the version it's enough. I'd say it's just a corner case...