### PR TITLE
Fixes #29501 - Adds i18n support for plugin

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,5 @@
+#!/usr/bin/env rake
+require "hammer_cli_foreman_azure_rm/version"
+require "hammer_cli_foreman_azure_rm/i18n"
+require "hammer_cli/i18n/find_task"
+HammerCLI::I18n::FindTask.define(HammerCLIForemanAzureRm::I18n::LocaleDomain.new, HammerCLIForemanAzureRm.version)

--- a/lib/hammer_cli_foreman_azure_rm/i18n.rb
+++ b/lib/hammer_cli_foreman_azure_rm/i18n.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'hammer_cli/i18n'
+module HammerCLIForemanAzureRm
+  module I18n
+    class LocaleDomain < HammerCLI::I18n::LocaleDomain
+      def translated_files
+        Dir.glob(File.join(File.dirname(__FILE__), '../**/*.rb'))
+      end
+
+      def locale_dir
+        File.join(File.dirname(__FILE__), '../../locale')
+      end
+
+      def domain_name
+        'hammer-cli-foreman-azure-rm'
+      end
+
+      def type
+        :mo
+      end
+    end
+  end
+end
+
+HammerCLI::I18n.add_domain(HammerCLIForemanAzureRm::I18n::LocaleDomain.new)
+

--- a/locale/Makefile
+++ b/locale/Makefile
@@ -1,0 +1,6 @@
+DOMAIN = hammer-cli-foreman-azure-rm
+VERSION = $(shell bundle exec ruby -C ../ -e 'require "rubygems"; spec = Gem::Specification::load("../hammer_cli_foreman_kubevirt.gemspec"); puts spec.version')
+MAIN_MAKEFILE = $(shell bundle exec ruby -C ../ -e 'require "hammer_cli"; puts HammerCLI::I18n.main_makefile')
+
+include $(MAIN_MAKEFILE)
+

--- a/locale/en/hammer-cli-foreman-azure-rm.edit.po
+++ b/locale/en/hammer-cli-foreman-azure-rm.edit.po
@@ -1,0 +1,91 @@
+# English translations for hammer-cli-foreman-azure-rm package.
+# Copyright (C) 2020 THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the hammer-cli-foreman-azure-rm package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2020.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: hammer-cli-foreman-azure-rm 0.1.2\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-04-07 21:19+0530\n"
+"PO-Revision-Date: 2020-04-07 21:19+0530\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: English\n"
+"Language: en\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"\n"
+
+#: ../lib/hammer_cli_foreman_azure_rm/compute_resources/azure_rm.rb:7
+msgid "AzureRM"
+msgstr ""
+
+#: ../lib/hammer_cli_foreman_azure_rm/compute_resources/azure_rm.rb:12
+msgid "Existing Azure Resource Group of user"
+msgstr ""
+
+#: ../lib/hammer_cli_foreman_azure_rm/compute_resources/azure_rm.rb:13
+msgid "VM Size, eg. Standard_A0 etc."
+msgstr ""
+
+#: ../lib/hammer_cli_foreman_azure_rm/compute_resources/azure_rm.rb:14
+msgid "The Admin username"
+msgstr ""
+
+#: ../lib/hammer_cli_foreman_azure_rm/compute_resources/azure_rm.rb:15
+msgid "The Admin password"
+msgstr ""
+
+#: ../lib/hammer_cli_foreman_azure_rm/compute_resources/azure_rm.rb:16
+msgid "OS type eg. Linux"
+msgstr ""
+
+#: ../lib/hammer_cli_foreman_azure_rm/compute_resources/azure_rm.rb:17
+msgid "SSH key for passwordless authentication"
+msgstr ""
+
+#: ../lib/hammer_cli_foreman_azure_rm/compute_resources/azure_rm.rb:18
+msgid "OS disk caching"
+msgstr ""
+
+#: ../lib/hammer_cli_foreman_azure_rm/compute_resources/azure_rm.rb:19
+msgid "Premium OS Disk, Boolean as 0 or 1"
+msgstr ""
+
+#: ../lib/hammer_cli_foreman_azure_rm/compute_resources/azure_rm.rb:20
+msgid "Custom Script Command"
+msgstr ""
+
+#: ../lib/hammer_cli_foreman_azure_rm/compute_resources/azure_rm.rb:21
+msgid "Comma seperated file URIs"
+msgstr ""
+
+#: ../lib/hammer_cli_foreman_azure_rm/compute_resources/azure_rm.rb:27
+msgid "Select one of available Azure Subnets, must be an ID"
+msgstr ""
+
+#: ../lib/hammer_cli_foreman_azure_rm/compute_resources/azure_rm.rb:28
+msgid "Public IP (None, Static, Dynamic)"
+msgstr ""
+
+#: ../lib/hammer_cli_foreman_azure_rm/compute_resources/azure_rm.rb:29
+msgid "Static Private IP (expressed as true or false)"
+msgstr ""
+
+#: ../lib/hammer_cli_foreman_azure_rm/compute_resources/azure_rm.rb:35
+msgid "tenant"
+msgstr ""
+
+#: ../lib/hammer_cli_foreman_azure_rm/compute_resources/azure_rm.rb:36
+msgid "app_ident"
+msgstr ""
+
+#: ../lib/hammer_cli_foreman_azure_rm/compute_resources/azure_rm.rb:37
+msgid "sub_id"
+msgstr ""
+
+#: ../lib/hammer_cli_foreman_azure_rm/compute_resources/azure_rm.rb:38
+msgid "region"
+msgstr ""

--- a/locale/en/hammer-cli-foreman-azure-rm.po
+++ b/locale/en/hammer-cli-foreman-azure-rm.po
@@ -1,0 +1,72 @@
+# English translations for hammer-cli-foreman-azure-rm package.
+# Copyright (C) 2020 THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the hammer-cli-foreman-azure-rm package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2020.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: hammer-cli-foreman-azure-rm 0.1.2\n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: 2020-04-07 21:19+0530\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: English\n"
+"Language: en\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"\n"
+
+msgid "AzureRM"
+msgstr ""
+
+msgid "Existing Azure Resource Group of user"
+msgstr ""
+
+msgid "VM Size, eg. Standard_A0 etc."
+msgstr ""
+
+msgid "The Admin username"
+msgstr ""
+
+msgid "The Admin password"
+msgstr ""
+
+msgid "OS type eg. Linux"
+msgstr ""
+
+msgid "SSH key for passwordless authentication"
+msgstr ""
+
+msgid "OS disk caching"
+msgstr ""
+
+msgid "Premium OS Disk, Boolean as 0 or 1"
+msgstr ""
+
+msgid "Custom Script Command"
+msgstr ""
+
+msgid "Comma seperated file URIs"
+msgstr ""
+
+msgid "Select one of available Azure Subnets, must be an ID"
+msgstr ""
+
+msgid "Public IP (None, Static, Dynamic)"
+msgstr ""
+
+msgid "Static Private IP (expressed as true or false)"
+msgstr ""
+
+msgid "tenant"
+msgstr ""
+
+msgid "app_ident"
+msgstr ""
+
+msgid "sub_id"
+msgstr ""
+
+msgid "region"
+msgstr ""

--- a/locale/hammer-cli-foreman-azure-rm.pot
+++ b/locale/hammer-cli-foreman-azure-rm.pot
@@ -1,0 +1,91 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the hammer-cli-foreman-azure-rm package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: hammer-cli-foreman-azure-rm 0.1.2\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-04-07 21:19+0530\n"
+"PO-Revision-Date: 2020-04-07 21:19+0530\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
+
+#: ../lib/hammer_cli_foreman_azure_rm/compute_resources/azure_rm.rb:7
+msgid "AzureRM"
+msgstr ""
+
+#: ../lib/hammer_cli_foreman_azure_rm/compute_resources/azure_rm.rb:12
+msgid "Existing Azure Resource Group of user"
+msgstr ""
+
+#: ../lib/hammer_cli_foreman_azure_rm/compute_resources/azure_rm.rb:13
+msgid "VM Size, eg. Standard_A0 etc."
+msgstr ""
+
+#: ../lib/hammer_cli_foreman_azure_rm/compute_resources/azure_rm.rb:14
+msgid "The Admin username"
+msgstr ""
+
+#: ../lib/hammer_cli_foreman_azure_rm/compute_resources/azure_rm.rb:15
+msgid "The Admin password"
+msgstr ""
+
+#: ../lib/hammer_cli_foreman_azure_rm/compute_resources/azure_rm.rb:16
+msgid "OS type eg. Linux"
+msgstr ""
+
+#: ../lib/hammer_cli_foreman_azure_rm/compute_resources/azure_rm.rb:17
+msgid "SSH key for passwordless authentication"
+msgstr ""
+
+#: ../lib/hammer_cli_foreman_azure_rm/compute_resources/azure_rm.rb:18
+msgid "OS disk caching"
+msgstr ""
+
+#: ../lib/hammer_cli_foreman_azure_rm/compute_resources/azure_rm.rb:19
+msgid "Premium OS Disk, Boolean as 0 or 1"
+msgstr ""
+
+#: ../lib/hammer_cli_foreman_azure_rm/compute_resources/azure_rm.rb:20
+msgid "Custom Script Command"
+msgstr ""
+
+#: ../lib/hammer_cli_foreman_azure_rm/compute_resources/azure_rm.rb:21
+msgid "Comma seperated file URIs"
+msgstr ""
+
+#: ../lib/hammer_cli_foreman_azure_rm/compute_resources/azure_rm.rb:27
+msgid "Select one of available Azure Subnets, must be an ID"
+msgstr ""
+
+#: ../lib/hammer_cli_foreman_azure_rm/compute_resources/azure_rm.rb:28
+msgid "Public IP (None, Static, Dynamic)"
+msgstr ""
+
+#: ../lib/hammer_cli_foreman_azure_rm/compute_resources/azure_rm.rb:29
+msgid "Static Private IP (expressed as true or false)"
+msgstr ""
+
+#: ../lib/hammer_cli_foreman_azure_rm/compute_resources/azure_rm.rb:35
+msgid "tenant"
+msgstr ""
+
+#: ../lib/hammer_cli_foreman_azure_rm/compute_resources/azure_rm.rb:36
+msgid "app_ident"
+msgstr ""
+
+#: ../lib/hammer_cli_foreman_azure_rm/compute_resources/azure_rm.rb:37
+msgid "sub_id"
+msgstr ""
+
+#: ../lib/hammer_cli_foreman_azure_rm/compute_resources/azure_rm.rb:38
+msgid "region"
+msgstr ""


### PR DESCRIPTION
Adding Internationalization support for azurerm. This basically extends the hammer-cli i18n implementation and so below commands are available,
~~~
# rake gettext:find - Update pot file
# make all-mo (default) - generate MO files
# make check - check translations using translate-tool
# make tx-update - download and merge translations from Transifex
# make clean - clean everything
~~~