### PR TITLE
Make gettext a development dependency

### DIFF
--- a/hammer_cli_foreman_azure_rm.gemspec
+++ b/hammer_cli_foreman_azure_rm.gemspec
@@ -13,8 +13,8 @@ Gem::Specification.new do |s|
   s.files = Dir['{lib,config}/**/*', 'LICENSE', 'README*']
   s.require_paths = ["lib"]
 
-  s.add_dependency 'gettext', '>= 3.1.3', '< 4.0.0'
   s.add_dependency 'hammer_cli_foreman', '>=0.17.0'
+  s.add_development_dependency 'gettext', '>= 3.1.3', '< 4.0.0'
   s.add_development_dependency 'rake', '~> 12.3'
   s.add_development_dependency 'rubocop', '~> 0.64'
 end


### PR DESCRIPTION
This is needed for the rake task to collect messages, but Hammer itself already provides the translation method.

This gem has no tests so I'm not sure I'm properly able to verify this. However https://bugzilla.redhat.com/show_bug.cgi?id=1994237 lead here so if we can avoid installing gettext that would be great.