### PR TITLE
Fix translation infrastructure

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,5 +4,5 @@ eval_gemfile(dev_gemfile) if File.exist?(dev_gemfile)
 gemspec
 
 group :test do
-  gem 'rake', '~> 10.1.0'
+  gem 'rake', '~> 13.0'
 end

--- a/locale/Makefile
+++ b/locale/Makefile
@@ -1,5 +1,5 @@
 DOMAIN = hammer-cli-foreman-azure-rm
-VERSION = $(shell bundle exec ruby -C ../ -e 'require "rubygems"; spec = Gem::Specification::load("../hammer_cli_foreman_azure_rm.gemspec"); puts spec.version')
+VERSION = $(shell bundle exec ruby -C ../ -e 'require "rubygems"; puts Gem::Specification::load("hammer_cli_foreman_azure_rm.gemspec").version')
 MAIN_MAKEFILE = $(shell bundle exec ruby -C ../ -e 'require "hammer_cli"; puts HammerCLI::I18n.main_makefile')
 
 include $(MAIN_MAKEFILE)


### PR DESCRIPTION
The current gettext rake task only works with rake 13. There are no other rake tasks, so the upgrade is safe. In addition, it solves a CVE.

This does require [a fix in hammer-cli](https://github.com/theforeman/hammer-cli/pull/361) before it really works.