### PR TITLE
Ignore Gemfile.dev.rb in git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+Gemfile.dev.rb
 Gemfile.lock


### PR DESCRIPTION
This file is optional and intended for developers to run things locally. As such, it should be ignored so it's not accidentally committed.

Open question: other places use Gemfile.local.rb. Should this be adjusted to match?